### PR TITLE
Add Extensions to ValidationPackage for conversion to ValidationPackageMetadata

### DIFF
--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -106,5 +106,20 @@ namespace AVPRClient
                     })
                 .ToArray();
         }
+
+        public static AVPRIndex.Domain.OntologyAnnotation[] toOntologyAnnotations(
+            this AVPRClient.ValidationPackage validationPackage
+        )
+        {
+            return validationPackage.Tags
+                .Select(tag =>
+                    new AVPRIndex.Domain.OntologyAnnotation
+                    {
+                        Name = tag.Name,
+                        TermSourceREF = tag.TermSourceREF,
+                        TermAccessionNumber = tag.TermAccessionNumber
+                    })
+                .ToArray();
+        }
     }
 }

--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -91,7 +91,7 @@ namespace AVPRClient
             }
         }
 
-        public static AVPRIndex.Domain.Author [] toAuthors (
+        public static AVPRIndex.Domain.Author [] GetAuthors (
             this AVPRClient.ValidationPackage validationPackage
         )
         {
@@ -107,7 +107,7 @@ namespace AVPRClient
                 .ToArray();
         }
 
-        public static AVPRIndex.Domain.OntologyAnnotation[] toOntologyAnnotations(
+        public static AVPRIndex.Domain.OntologyAnnotation[] GetOntologyAnnotations(
             this AVPRClient.ValidationPackage validationPackage
         )
         {
@@ -134,8 +134,8 @@ namespace AVPRClient
                 validationPackage.MinorVersion,
                 validationPackage.PatchVersion,
                 Microsoft.FSharp.Core.FSharpOption<bool>.None,
-                validationPackage.toAuthors(),
-                validationPackage.toOntologyAnnotations(),
+                validationPackage.GetAuthors(),
+                validationPackage.GetOntologyAnnotations(),
                 validationPackage.ReleaseNotes
             );
         }

--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -91,7 +91,7 @@ namespace AVPRClient
             }
         }
 
-        public static AVPRIndex.Domain.Author [] GetAuthors (
+        public static AVPRIndex.Domain.Author [] AsIndexType (
             this ICollection<Author> authors
         )
         {
@@ -107,7 +107,7 @@ namespace AVPRClient
                 .ToArray();
         }
 
-        public static AVPRIndex.Domain.OntologyAnnotation[] GetOntologyAnnotations(
+        public static AVPRIndex.Domain.OntologyAnnotation[] AsIndexType(
             this ICollection<OntologyAnnotation> ontologyAnnotations
         )
         {
@@ -134,8 +134,8 @@ namespace AVPRClient
                 validationPackage.MinorVersion,
                 validationPackage.PatchVersion,
                 Microsoft.FSharp.Core.FSharpOption<bool>.None,
-                validationPackage.Authors.GetAuthors(),
-                validationPackage.Tags.GetOntologyAnnotations(),
+                validationPackage.Authors.AsIndexType(),
+                validationPackage.Tags.AsIndexType(),
                 validationPackage.ReleaseNotes
             );
         }

--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -121,5 +121,23 @@ namespace AVPRClient
                     })
                 .ToArray();
         }
+
+        public static AVPRIndex.Domain.ValidationPackageMetadata toValidationPackageMetadata(
+            this AVPRClient.ValidationPackage validationPackage
+        )
+        {
+            return Domain.ValidationPackageMetadata.create(
+                validationPackage.Name,
+                validationPackage.Summary,
+                validationPackage.Description,
+                validationPackage.MajorVersion,
+                validationPackage.MinorVersion,
+                validationPackage.PatchVersion,
+                Microsoft.FSharp.Core.FSharpOption<bool>.None,
+                validationPackage.toAuthors(),
+                validationPackage.toOntologyAnnotations(),
+                validationPackage.ReleaseNotes
+            );
+        }
     }
 }

--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -90,5 +90,21 @@ namespace AVPRClient
                 };
             }
         }
+
+        public static AVPRIndex.Domain.Author [] toAuthors (
+            this AVPRClient.ValidationPackage validationPackage
+        )
+        {
+            return validationPackage.Authors
+                .Select(author =>
+                    new AVPRIndex.Domain.Author
+                    {
+                        FullName = author.FullName,
+                        Email = author.Email,
+                        Affiliation = author.Affiliation,
+                        AffiliationLink = author.AffiliationLink
+                    })
+                .ToArray();
+        }
     }
 }

--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -92,10 +92,10 @@ namespace AVPRClient
         }
 
         public static AVPRIndex.Domain.Author [] GetAuthors (
-            this AVPRClient.ValidationPackage validationPackage
+            this ICollection<Author> authors
         )
         {
-            return validationPackage.Authors
+            return authors
                 .Select(author =>
                     new AVPRIndex.Domain.Author
                     {
@@ -108,10 +108,10 @@ namespace AVPRClient
         }
 
         public static AVPRIndex.Domain.OntologyAnnotation[] GetOntologyAnnotations(
-            this AVPRClient.ValidationPackage validationPackage
+            this ICollection<OntologyAnnotation> ontologyAnnotations
         )
         {
-            return validationPackage.Tags
+            return ontologyAnnotations
                 .Select(tag =>
                     new AVPRIndex.Domain.OntologyAnnotation
                     {
@@ -134,8 +134,8 @@ namespace AVPRClient
                 validationPackage.MinorVersion,
                 validationPackage.PatchVersion,
                 Microsoft.FSharp.Core.FSharpOption<bool>.None,
-                validationPackage.GetAuthors(),
-                validationPackage.GetOntologyAnnotations(),
+                validationPackage.Authors.GetAuthors(),
+                validationPackage.Tags.GetOntologyAnnotations(),
                 validationPackage.ReleaseNotes
             );
         }


### PR DESCRIPTION
This PR adds extensions for the conversion of ValidationPackage to ValidationPackageMetadata and the subsequently required extensions for conversion of ValidationPackage to OntologyAnnotations and Authors.