### PR TITLE
Add support for hook endpoint to Index model

### DIFF
--- a/src/AVPRClient/Extensions.cs
+++ b/src/AVPRClient/Extensions.cs
@@ -136,7 +136,8 @@ namespace AVPRClient
                 Microsoft.FSharp.Core.FSharpOption<bool>.None,
                 validationPackage.Authors.AsIndexType(),
                 validationPackage.Tags.AsIndexType(),
-                validationPackage.ReleaseNotes
+                validationPackage.ReleaseNotes,
+                Microsoft.FSharp.Core.FSharpOption<string>.None
             );
         }
     }

--- a/src/AVPRIndex/AVPRIndex.fsproj
+++ b/src/AVPRIndex/AVPRIndex.fsproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/RELEASE_NOTES.md"))</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageVersion>0.1.0</PackageVersion>
+    <PackageVersion>0.1.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AVPRIndex/Domain.fs
+++ b/src/AVPRIndex/Domain.fs
@@ -106,7 +106,7 @@ module Domain =
         member val Authors: Author [] = Array.empty<Author> with get,set
         member val Tags: OntologyAnnotation [] = Array.empty<OntologyAnnotation> with get,set
         member val ReleaseNotes = "" with get,set
-        member val HookEndpoint = "" with get,set
+        member val CQCHookEndpoint = "" with get,set
 
         override this.GetHashCode() =
             hash (
@@ -120,7 +120,7 @@ module Domain =
                 this.Authors,
                 this.Tags,
                 this.ReleaseNotes,
-                this.HookEndpoint
+                this.CQCHookEndpoint
             )
 
         override this.Equals(other) =
@@ -137,7 +137,7 @@ module Domain =
                     this.Authors,
                     this.Tags,
                     this.ReleaseNotes,
-                    this.HookEndpoint
+                    this.CQCHookEndpoint
                 ) = (
                     vpm.Name, 
                     vpm.Summary, 
@@ -149,7 +149,7 @@ module Domain =
                     vpm.Authors,
                     vpm.Tags,
                     vpm.ReleaseNotes,
-                    vpm.HookEndpoint
+                    vpm.CQCHookEndpoint
                 )
             | _ -> false
         
@@ -164,7 +164,7 @@ module Domain =
             ?Authors: Author [],
             ?Tags: OntologyAnnotation [],
             ?ReleaseNotes,
-            ?HookEndpoint
+            ?CQCHookEndpoint
         ) = 
             let tmp = ValidationPackageMetadata(
                 Name = name,
@@ -179,7 +179,7 @@ module Domain =
             Authors |> Option.iter (fun x -> tmp.Authors <- x)
             Tags |> Option.iter (fun x -> tmp.Tags <- x)
             ReleaseNotes |> Option.iter (fun x -> tmp.ReleaseNotes <- x)
-            HookEndpoint |> Option.iter (fun x -> tmp.HookEndpoint <- x)
+            CQCHookEndpoint |> Option.iter (fun x -> tmp.CQCHookEndpoint <- x)
         
             tmp
         

--- a/src/AVPRIndex/Domain.fs
+++ b/src/AVPRIndex/Domain.fs
@@ -106,6 +106,7 @@ module Domain =
         member val Authors: Author [] = Array.empty<Author> with get,set
         member val Tags: OntologyAnnotation [] = Array.empty<OntologyAnnotation> with get,set
         member val ReleaseNotes = "" with get,set
+        member val HookEndpoint = "" with get,set
 
         override this.GetHashCode() =
             hash (
@@ -118,7 +119,8 @@ module Domain =
                 this.Publish,
                 this.Authors,
                 this.Tags,
-                this.ReleaseNotes
+                this.ReleaseNotes,
+                this.HookEndpoint
             )
 
         override this.Equals(other) =
@@ -134,7 +136,8 @@ module Domain =
                     this.Publish,
                     this.Authors,
                     this.Tags,
-                    this.ReleaseNotes
+                    this.ReleaseNotes,
+                    this.HookEndpoint
                 ) = (
                     vpm.Name, 
                     vpm.Summary, 
@@ -145,7 +148,8 @@ module Domain =
                     vpm.Publish,
                     vpm.Authors,
                     vpm.Tags,
-                    vpm.ReleaseNotes
+                    vpm.ReleaseNotes,
+                    vpm.HookEndpoint
                 )
             | _ -> false
         
@@ -159,7 +163,8 @@ module Domain =
             ?Publish: bool,
             ?Authors: Author [],
             ?Tags: OntologyAnnotation [],
-            ?ReleaseNotes
+            ?ReleaseNotes,
+            ?HookEndpoint
         ) = 
             let tmp = ValidationPackageMetadata(
                 Name = name,
@@ -174,6 +179,7 @@ module Domain =
             Authors |> Option.iter (fun x -> tmp.Authors <- x)
             Tags |> Option.iter (fun x -> tmp.Tags <- x)
             ReleaseNotes |> Option.iter (fun x -> tmp.ReleaseNotes <- x)
+            HookEndpoint |> Option.iter (fun x -> tmp.HookEndpoint <- x)
         
             tmp
         

--- a/src/AVPRIndex/RELEASE_NOTES.md
+++ b/src/AVPRIndex/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## v0.1.1
+
+Add `CQCHookEndpoint` field to `ValidationPackageMetadata`
+
 ## v0.1.0
 
 Add support for in-package frontmatter bindings. Enables re-use of the frontmatter inside the package code

--- a/tests/IndexTests/DomainTests.fs
+++ b/tests/IndexTests/DomainTests.fs
@@ -80,6 +80,6 @@ module ValidationPackageMetadata =
                 )
             |],
             ReleaseNotes = "releasenotes",
-            HookEndpoint = "hookendpoint"
+            CQCHookEndpoint = "hookendpoint"
         )
         Assert.Equivalent(ValidationPackageMetadata.allFields, actual)

--- a/tests/IndexTests/DomainTests.fs
+++ b/tests/IndexTests/DomainTests.fs
@@ -39,3 +39,47 @@ module OntologyAnnotation =
             TermAccessionNumber = "TAN"
         )
         Assert.Equivalent(OntologyAnnotation.allFields, actual)
+
+module ValidationPackageMetadata =
+    
+    [<Fact>]
+    let ``create function for mandatory fields``() =
+        let actual = ValidationPackageMetadata.create(
+            name = "name",
+            summary = "summary" ,
+            description = "description" ,
+            majorVersion = 1,
+            minorVersion = 0,
+            patchVersion = 0
+        )
+        Assert.Equivalent(ValidationPackageMetadata.mandatoryFields, actual)
+
+    [<Fact>]
+    let ``create function for all fields``() =
+        let actual = ValidationPackageMetadata.create(
+            name = "name",
+            summary = "summary" ,
+            description = "description" ,
+            majorVersion = 1,
+            minorVersion = 0,
+            patchVersion = 0,
+            Publish = true,
+            Authors = [|
+                Author.create(
+                    fullName = "test", 
+                    Email = "test@test.test",
+                    Affiliation = "testaffiliation",
+                    AffiliationLink = "test.com"
+                )
+            |],
+            Tags = [|
+            OntologyAnnotation.create(
+                    name = "test",
+                    TermSourceREF = "REF",
+                    TermAccessionNumber = "TAN"
+                )
+            |],
+            ReleaseNotes = "releasenotes",
+            HookEndpoint = "hookendpoint"
+        )
+        Assert.Equivalent(ValidationPackageMetadata.allFields, actual)

--- a/tests/IndexTests/ReferenceObjects.fs
+++ b/tests/IndexTests/ReferenceObjects.fs
@@ -50,7 +50,7 @@ module ValidationPackageMetadata =
         Authors = [|Author.allFields|],
         Tags = [|OntologyAnnotation.allFields|],
         ReleaseNotes = "releasenotes",
-        HookEndpoint = "hookendpoint"
+        CQCHookEndpoint = "hookendpoint"
     )
 
 module Frontmatter = 
@@ -114,7 +114,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
-HookEndpoint: https://hook.com
+CQCHookEndpoint: https://hook.com
 ---
 *)"""                                                                         .ReplaceLineEndings("\n")
 
@@ -147,7 +147,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
-HookEndpoint: https://hook.com
+CQCHookEndpoint: https://hook.com
 """                                                                         .ReplaceLineEndings("\n")
 
         let invalidStartFrontmatter = """(
@@ -259,7 +259,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
-HookEndpoint: https://hook.com
+CQCHookEndpoint: https://hook.com
 ---
 *)\"\"\""                                                                         .ReplaceLineEndings("\n")
 
@@ -292,7 +292,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
-HookEndpoint: https://hook.com
+CQCHookEndpoint: https://hook.com
 """                                                                         .ReplaceLineEndings("\n")
 
         let invalidStartFrontmatter = "let [<Literal>]PACKAGE_METADATA = \"\"\"
@@ -395,7 +395,7 @@ It does it very fast, it does it very swell.
   - does the thing
   - does it well
 """.ReplaceLineEndings("\n"),
-            HookEndpoint = "https://hook.com"
+            CQCHookEndpoint = "https://hook.com"
         )
 
     let invalidMissingMandatoryFrontmatter = 

--- a/tests/IndexTests/ReferenceObjects.fs
+++ b/tests/IndexTests/ReferenceObjects.fs
@@ -28,6 +28,31 @@ module OntologyAnnotation =
         TermAccessionNumber = "TAN"
     )
 
+module ValidationPackageMetadata = 
+    
+    let mandatoryFields = ValidationPackageMetadata(
+        Name = "name",
+        Summary = "summary" ,
+        Description = "description" ,
+        MajorVersion = 1,
+        MinorVersion = 0,
+        PatchVersion = 0
+    )
+
+    let allFields = ValidationPackageMetadata(
+        Name = "name",
+        Summary = "summary" ,
+        Description = "description" ,
+        MajorVersion = 1,
+        MinorVersion = 0,
+        PatchVersion = 0,
+        Publish = true,
+        Authors = [|Author.allFields|],
+        Tags = [|OntologyAnnotation.allFields|],
+        ReleaseNotes = "releasenotes",
+        HookEndpoint = "hookendpoint"
+    )
+
 module Frontmatter = 
 
     module Comment =
@@ -89,6 +114,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
+HookEndpoint: https://hook.com
 ---
 *)"""                                                                         .ReplaceLineEndings("\n")
 
@@ -121,6 +147,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
+HookEndpoint: https://hook.com
 """                                                                         .ReplaceLineEndings("\n")
 
         let invalidStartFrontmatter = """(
@@ -232,6 +259,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
+HookEndpoint: https://hook.com
 ---
 *)\"\"\""                                                                         .ReplaceLineEndings("\n")
 
@@ -264,6 +292,7 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
+HookEndpoint: https://hook.com
 """                                                                         .ReplaceLineEndings("\n")
 
         let invalidStartFrontmatter = "let [<Literal>]PACKAGE_METADATA = \"\"\"
@@ -365,7 +394,8 @@ It does it very fast, it does it very swell.
             ReleaseNotes = """- initial release
   - does the thing
   - does it well
-""".ReplaceLineEndings("\n")
+""".ReplaceLineEndings("\n"),
+            HookEndpoint = "https://hook.com"
         )
 
     let invalidMissingMandatoryFrontmatter = 

--- a/tests/IndexTests/fixtures/Frontmatter/Binding/valid@2.0.0.fsx
+++ b/tests/IndexTests/fixtures/Frontmatter/Binding/valid@2.0.0.fsx
@@ -28,6 +28,6 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
-HookEndpoint: https://hook.com
+CQCHookEndpoint: https://hook.com
 ---
 *)"""

--- a/tests/IndexTests/fixtures/Frontmatter/Binding/valid@2.0.0.fsx
+++ b/tests/IndexTests/fixtures/Frontmatter/Binding/valid@2.0.0.fsx
@@ -28,5 +28,6 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
+HookEndpoint: https://hook.com
 ---
 *)"""

--- a/tests/IndexTests/fixtures/Frontmatter/Comment/valid@2.0.0.fsx
+++ b/tests/IndexTests/fixtures/Frontmatter/Comment/valid@2.0.0.fsx
@@ -28,5 +28,6 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
+HookEndpoint: https://hook.com
 ---
 *)

--- a/tests/IndexTests/fixtures/Frontmatter/Comment/valid@2.0.0.fsx
+++ b/tests/IndexTests/fixtures/Frontmatter/Comment/valid@2.0.0.fsx
@@ -28,6 +28,6 @@ ReleaseNotes: |
   - initial release
     - does the thing
     - does it well
-HookEndpoint: https://hook.com
+CQCHookEndpoint: https://hook.com
 ---
 *)


### PR DESCRIPTION
This PR will add support for optional hook endpoints in validation package metadata. This is compliant with ARC-specification v2.0.0 which defines an optional hook endpoint that can be triggered by validation packages being run.

#35 