### PR TITLE
Publish ontology-terms v1.0.0

### DIFF
--- a/StagingArea/ontology-terms/ontology-terms@1.0.0.py
+++ b/StagingArea/ontology-terms/ontology-terms@1.0.0.py
@@ -4,7 +4,7 @@ Name: ontology-terms
 MajorVersion: 1
 MinorVersion: 0
 PatchVersion: 0
-Publish: false
+Publish: true
 Summary: Validates that ontology/CV annotations in ARC ISA tables are complete, well-formed, declared, and resolvable.
 Description: |
   Checks the quality of ontology / controlled-vocabulary annotations on


### PR DESCRIPTION
Sorry, forgot to flip Publish to true for the already-reviewed ontology-terms@1.0.0 package so it can be pushed to the production registry. No content changes from the merged version.